### PR TITLE
Made the About label translatable

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -986,6 +986,10 @@ msgstr ""
 msgid "Sensor 2"
 msgstr "Sensor 2"
 
+#: prefs.js:715
+msgid "About"
+msgstr ""
+
 #: prefs.js:716
 msgid "Info"
 msgstr "Info"

--- a/po/monitor@astraext.pot
+++ b/po/monitor@astraext.pot
@@ -945,6 +945,10 @@ msgstr ""
 msgid "Sensor 2"
 msgstr ""
 
+#: prefs.js:715
+msgid "About"
+msgstr ""
+
 #: prefs.js:716
 msgid "Info"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -986,6 +986,10 @@ msgstr "Установите -1 для авто. Количество цифр �
 msgid "Sensor 2"
 msgstr "Датчик 2"
 
+#: prefs.js:715
+msgid "About"
+msgstr ""
+
 #: prefs.js:716
 msgid "Info"
 msgstr "Информация"

--- a/prefs.ts
+++ b/prefs.ts
@@ -875,7 +875,7 @@ export default class AstraMonitorPrefs extends ExtensionPreferences {
     }
     
     private setupAbout() {
-        const aboutPage = new Adw.PreferencesPage({title: 'About', icon_name: 'am-dialog-info-symbolic'});
+        const aboutPage = new Adw.PreferencesPage({title: _('About'), icon_name: 'am-dialog-info-symbolic'});
         
         const group = new Adw.PreferencesGroup({title: _('Info')});
         


### PR DESCRIPTION
I noticed that the About label can't be translated at the moment. If it is a bug, I offer a solution.