### PR TITLE
Ensure PCI id is lower case so it matches the case of lspci.

### DIFF
--- a/src/gpu/gpuMonitor.ts
+++ b/src/gpu/gpuMonitor.ts
@@ -1167,7 +1167,7 @@ export default class GpuMonitor extends Monitor {
             for(const gpuInfo of gpuInfoList) {
                 if(!gpuInfo['@id']) continue;
 
-                let id = gpuInfo['@id'];
+                let id = gpuInfo['@id'].toString().toLowerCase();
                 if(id.startsWith('00000000:')) id = id.slice(4);
 
                 const gpu: NvidiaInfo = {


### PR DESCRIPTION
For me this fixes https://github.com/AstraExt/astra-monitor/issues/131.
`nvidia-smi` outputs PCI id's as `00000000:0B:00.0` while `lspci` lists the PCI-id as `0b:00.0` (capital vs lower `B`).
This fix ensures the case matches so the extension can pick the right PCI-id for the stats to be loaded.
