### PR TITLE
Bug fix: CPU frequency unit in header was MHz, now fixed to GHz

### DIFF
--- a/src/processor/processorHeader.ts
+++ b/src/processor/processorHeader.ts
@@ -416,15 +416,15 @@ export default GObject.registerClass(
             if(this.frequencyMode === 'average') {
                 const sum = frequency.reduce((a, b) => a + b, 0);
                 this.frequency.text = Utils.formatFrequency(
-                    sum / frequency.length / 1000,
-                    'MHz',
+                    sum / frequency.length / 1000, /** Convert to GHz  */
+                    'GHz',
                     figures,
                     true
                 );
             } else if(this.frequencyMode === 'max') {
                 this.frequency.text = Utils.formatFrequency(
-                    Math.max(...frequency) / 1000,
-                    'MHz',
+                    Math.max(...frequency) / 1000, /** Convert to GHz  */
+                    'GHz',
                     figures,
                     true
                 );

--- a/src/processor/processorMonitor.ts
+++ b/src/processor/processorMonitor.ts
@@ -777,6 +777,14 @@ export default class ProcessorMonitor extends Monitor {
         };
     }
 
+    /**
+     * Reading frequency from /sys/devices/system/cpu/cpu<N>/cpufreq/scaling_cur_freq
+     * This read frequency in KHz. This function read the frequency and converts it in MHz
+     * by dividing it with 1000.
+     * 
+     * source: https://www.kernel.org/doc/Documentation/cpu-freq/user-guide.txt#:~:text=scaling_cur_freq%20%3A%20Current%20frequency%20of%20the,and%20cpufreq%20core%2C%20in%20KHz. 
+     *
+    */
     async updateCpuCoresFrequencyProc(): Promise<boolean> {
         if(this.isListeningFor('cpuCoresFrequency')) {
             try {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1712,7 +1712,7 @@ export default class Utils {
                 return id;
             }
         }
-        if(disks.size > 0) return disks.keys().next().value;
+        if(disks.size > 0) return disks.keys().next().value || null;
         return null;
     }
 


### PR DESCRIPTION
Fixed: #153

Other Changes:
 - typescript correct return type `string | null` instead of `string | undefined`
 - commented and added reference in `updateCpuCoresFrequencyProc()`