### PR TITLE
Only set GPU as selected if saved choice is found 

### DIFF
--- a/src/prefs/prefsUtils.ts
+++ b/src/prefs/prefsUtils.ts
@@ -447,7 +447,9 @@ export default class PrefsUtils {
             });
 
             select.set_model(stringList);
-            select.selected = selected;
+            if(selected >= 0) {
+                select.selected = selected;
+            }
 
             resetSignal = resetButton?.connect('clicked', () => {
                 choices.forEach((choice, index) => {


### PR DESCRIPTION
For me this fixes #194 
The gpu choice selector on the GPU setting pane throws an error on Gnome 48 when being set to a negative value.  The same `-1` does not cause an error when the drop down is initially created so I just added a check after searching for a matching saved value.