### PR TITLE
fix: activate signals don't fire

### DIFF
--- a/src/prefs/prefsUtils.ts
+++ b/src/prefs/prefsUtils.ts
@@ -276,8 +276,8 @@ export default class PrefsUtils {
         if(!isCallback) {
             Config.bind(setting, toggle, 'active', Gio.SettingsBindFlags.DEFAULT);
         } else {
-            toggle.connect('activate', widget => {
-                setting.set(!widget.active);
+            toggle.connect('state-set', (_, state) => {
+                setting.set(state);
             });
             Config.connect(this, 'changed::' + setting.watch, () => {
                 toggle.active = setting.get();


### PR DESCRIPTION
According to gjs documentation, use of `activate` signals is discouraged since it's meant for internal animation use. Either use property binds or the `state-set` signal. On my machine, `activate` doesn't even fire, effectively disabling gpu monitors and others that use this type of control switch. This PR fixes this issue.