### PR TITLE
fix: Handling comments now delivered in `nvidia-smi -q -x`, fixes issue #226

### DIFF
--- a/src/utils/xmlParser.ts
+++ b/src/utils/xmlParser.ts
@@ -56,6 +56,13 @@ export default class XMLParser {
 
             if(this.xml[this.pos] === '<') {
                 if(this.xml[this.pos + 1] === '/') {
+                    // handle comments
+                    if (this.xml.startsWith('<!--', this.pos)) {
+                        const endComment = this.xml.indexOf('-->', this.pos);
+                        this.pos = endComment !== -1 ? endComment + 3 : this.xml.length;
+                        continue;
+                    }
+                    
                     // Closing tag
                     this.pos = this.xml.indexOf('>', this.pos) + 1;
                     const finishedObject = this.stack.pop();


### PR DESCRIPTION
I experienced the issue where astra monitor no longer monitored my Nvidia GPU on driver version 610.43.02. On driver version 610.43.02, the output of `nvdia-smi -q -x` includes XML comments. 

These XML comments were not yet parsed in the xmlParser which is used for in gpuMonitor.

These changes should fix issue #226 