### PR TITLE
fix(metadata): add GNOME Shell version 51 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "name": "Astra Monitor",
     "uuid": "monitor@astraext.github.io",
     "description": "Astra Monitor is a cutting-edge, fully customizable, and performance-focused system monitoring extension for GNOME's top bar. It's an all-in-one solution for those seeking to keep a close eye on their system's performance metrics like CPU, GPU, RAM, disk usage, network statistics, and sensor readings.",
-    "shell-version": ["45", "46", "47", "48", "49", "50"],
+    "shell-version": ["45", "46", "47", "48", "49", "50", "51"],
     "url": "https://github.com/AstraExt/astra-monitor",
     "settings-schema": "org.gnome.shell.extensions.astra-monitor",
     "gettext-domain": "monitor@astraext.github.io",


### PR DESCRIPTION
Adding "51" to the metadata file just works :)