### PR TITLE
fix: flush final lspci block and normalise non-zero PCI domains

### DIFF
--- a/src/gpu/gpuMonitor.ts
+++ b/src/gpu/gpuMonitor.ts
@@ -1292,7 +1292,7 @@ export default class GpuMonitor extends Monitor {
                 if(!gpuInfo['@id']) continue;
 
                 let id = gpuInfo['@id'].toString().toLowerCase();
-                if(id.startsWith('00000000:')) id = id.slice(4);
+                if(/^[0-9a-f]{8}:/.test(id)) id = id.slice(4);
 
                 const gpu: NvidiaInfo = {
                     id,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -864,6 +864,9 @@ export default class Utils {
             collecting = collect;
             collecting--;
         }
+
+        if(result.length > 0) results.push(result.join('\n'));
+
         return results;
     }
 


### PR DESCRIPTION
Fixes the two defects described in #235.

Both are hit on any host where the GPU is the last device in `lspci` output, or
where the GPU sits on a non-zero PCI domain. Together they present as a single
symptom — **"No GPU found"**, then `-%` once detection is fixed.

### 1. `filterLspciOutput` drops the final device block — `src/utils/utils.ts`

A completed device block is pushed into `results` only at the *start* of a
following loop iteration. There is no flush after the loop terminates, so if the
matched device is the **last** entry in `lspci` output its block is still sitting
in the `result` buffer when the loop exits, and it is silently discarded.
`parseLspciGpuList` then returns `[]` and the UI reports "No GPU found".

This is not vendor-, arch-, or driver-specific — any machine whose GPU happens to
be the last device in `lspci -nnk` is affected.

```ts
        if(result.length > 0) results.push(result.join('\n'));

        return results;
```

### 2. PCI domain normalisation assumes an all-zero domain — `src/gpu/gpuMonitor.ts`

`nvidia-smi` pads the PCI domain to 8 hex digits where `lspci` uses 4. The
existing check only strips that padding when the domain is all zeros, so on a
host with a non-zero PCI domain the `nvidia-smi` key never matches the
`lspci`-derived key from `Utils.getGpuUUID`, and telemetry is gathered and then
dropped at lookup.

This is the same normalisation site #149 touched when fixing #131: the id was
lower-cased to match `lspci`, but the domain-pad half of the mismatch survived.
Same presentation there too — detection fine, stats blank.

```ts
        if(/^[0-9a-f]{8}:/.test(id)) id = id.slice(4);
```

| input | before | after |
|---|---|---|
| `0000000f:01:00.0` | `0000000f:01:00.0` ✗ | `000f:01:00.0` ✓ |
| `00000000:01:00.0` | `0000:01:00.0` | `0000:01:00.0` (unchanged) |
| `0000:01:00.0` | `0000:01:00.0` | `0000:01:00.0` (unchanged) |

A 4-digit domain is never matched by the regex — the `:` at index 4 is not a hex
digit — so existing hosts are unaffected.

### Testing

Both defects reproduce on an **NVIDIA DGX Spark** (GB10, aarch64, driver
580.173.02, Ubuntu 24.04.4, GNOME Shell 46.0 / X11) with the GPU at
`000f:01:00.0` — a non-zero domain, and the last device in `lspci -nnk`. I
confirmed the fix live on that machine by applying these same two edits to the
installed compiled extension and restarting the shell: the GPU appears in
Preferences → GPU → Main GPU, and activity and temperature update live in the
panel. This branch carries the identical logic in the TypeScript sources.

Beyond the on-hardware check I ran the real `filterLspciOutput`,
`parseLspciGpuList` and `getGpuUUID` bodies — extracted from the sources rather
than reimplemented — against this machine's actual `lspci -nnk` capture, on both
`main` and this branch. 31 assertions, covering the fix, the end-to-end key
match against `nvidia-smi`, and regressions:

- with the GPU **not** last, patched output is byte-identical to `main`
- empty input and no-match input produce no spurious block
- all-zero and 4-digit domains normalise exactly as before

I kept that harness out of the diff since the repo has no test setup — happy
to contribute it separately if you'd find it useful (it runs on both node and
`gjs`).

One thing I did *not* touch: `collect` is 5 counting from the matched line, and
`lspci` emits no blank line between devices, so a 4-line device block
over-collects the following device's header line. That is pre-existing and
orthogonal to this fix; I've pinned it in my own tests so it isn't mistaken for
a regression, but left the behaviour alone.